### PR TITLE
Add Stop & Shop price collector extension

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,12 @@
+let results = [];
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.set({ results: [] });
+});
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.name && msg.price && msg.url) {
+    results.push(msg);
+    chrome.storage.local.set({ results });
+  }
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,9 @@
+setTimeout(() => {
+  const nameEl = document.querySelector('span.sr-only');
+  const priceEl = document.querySelector('span.product-grid-cell_main-price');
+  if (nameEl && priceEl) {
+    const name = nameEl.textContent.trim();
+    const price = priceEl.textContent.trim();
+    chrome.runtime.sendMessage({ name, price, url: window.location.href });
+  }
+}, 1000);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "Stop & Shop Product Price Collector",
+  "description": "Collect product names and prices from Stop & Shop and export to CSV.",
+  "version": "1.0",
+  "permissions": [
+    "tabs",
+    "scripting",
+    "storage",
+    "downloads"
+  ],
+  "host_permissions": ["https://stopandshop.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://stopandshop.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Stop & Shop Price Collector"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Stop & Shop Price Collector</title>
+</head>
+<body>
+  <button id="download">Download CSV</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,20 @@
+function buildCSV(data) {
+  const header = 'Name,Price,URL\n';
+  const rows = data.map(item => `${item.name},${item.price},${item.url}`).join('\n');
+  return header + rows;
+}
+
+function downloadCSV(csv) {
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  chrome.downloads.download({ url, filename: 'beef_prices.csv', saveAs: true }, () => {
+    URL.revokeObjectURL(url);
+  });
+}
+
+document.getElementById('download').addEventListener('click', () => {
+  chrome.storage.local.get({ results: [] }, (data) => {
+    const csv = buildCSV(data.results);
+    downloadCSV(csv);
+  });
+});


### PR DESCRIPTION
## Summary
- create Chrome extension for collecting product names and prices from Stop & Shop pages
- background service worker stores results in `chrome.storage`
- content script extracts name and price
- popup allows CSV download

## Testing
- `node -c extension/background.js`
- `node -c extension/content.js`
- `node -c extension/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_684ac21b934883298107d5b50afa43fd