### PR TITLE
Add item count badge and popup display

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2,14 +2,18 @@ let results = [];
 
 chrome.runtime.onInstalled.addListener(() => {
   chrome.storage.local.set({ results: [] });
+  chrome.action.setBadgeBackgroundColor({ color: '#FF0000' });
+  chrome.action.setBadgeText({ text: '0' });
 });
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (Array.isArray(msg.items)) {
     results = results.concat(msg.items);
     chrome.storage.local.set({ results });
+    chrome.action.setBadgeText({ text: String(results.length) });
   } else if (msg.name && msg.price && msg.url) {
     results.push({ name: msg.name, price: msg.price, url: msg.url });
     chrome.storage.local.set({ results });
+    chrome.action.setBadgeText({ text: String(results.length) });
   }
 });

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -5,6 +5,9 @@
   <title>Stop & Shop Price Collector</title>
 </head>
 <body>
+  <div>
+    Items Extracted: <span id="item-count">0</span>
+  </div>
   <button id="download">Download CSV</button>
   <script src="popup.js"></script>
 </body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -12,9 +12,20 @@ function downloadCSV(csv) {
   });
 }
 
+const countEl = document.getElementById('item-count');
+
+function updateCount() {
+  chrome.storage.local.get({ results: [] }, (data) => {
+    countEl.textContent = data.results.length.toString();
+  });
+}
+
 document.getElementById('download').addEventListener('click', () => {
   chrome.storage.local.get({ results: [] }, (data) => {
     const csv = buildCSV(data.results);
     downloadCSV(csv);
   });
 });
+
+document.addEventListener('DOMContentLoaded', updateCount);
+chrome.storage.onChanged.addListener(updateCount);


### PR DESCRIPTION
## Summary
- display extracted item count in the popup
- show badge on the extension icon with the total items collected

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684acc9be73c8329a70f393039a22e34