### PR TITLE
Fix dynamic scrape timing

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-setTimeout(() => {
+function scrapeItems() {
   const containers = document.querySelectorAll(
     '.product-grid-cell_price-container'
   );
@@ -16,5 +16,20 @@ setTimeout(() => {
   });
   if (items.length) {
     chrome.runtime.sendMessage({ items });
+    return true;
   }
-}, 1000);
+  return false;
+}
+
+let attempts = 0;
+const maxAttempts = 10;
+
+function tryScrape() {
+  attempts += 1;
+  if (scrapeItems() || attempts >= maxAttempts) {
+    clearInterval(intervalId);
+  }
+}
+
+const intervalId = setInterval(tryScrape, 1000);
+tryScrape();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,13 +9,19 @@
     "storage",
     "downloads"
   ],
-  "host_permissions": ["https://stopandshop.com/*"],
+  "host_permissions": [
+    "https://stopandshop.com/*",
+    "https://www.stopandshop.com/*"
+  ],
   "background": {
     "service_worker": "background.js"
   },
   "content_scripts": [
     {
-      "matches": ["https://stopandshop.com/*"],
+      "matches": [
+        "https://stopandshop.com/*",
+        "https://www.stopandshop.com/*"
+      ],
       "js": ["content.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
## Summary
- improve the content script to retry scraping until items load
- allow extension to run on `www.stopandshop.com` hosts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad75b55d8832984d95d8f6d1e61e6